### PR TITLE
Sync with Pro

### DIFF
--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -484,15 +484,16 @@ class ScanHandler:
         # minutes to wait for completion. Eventually, this wait may
         # be configurable as we see larger scans and increased backend
         # load.
-        try_until = datetime.utcnow() + timedelta(minutes=30)
-        slow_down_after = datetime.utcnow() + timedelta(minutes=2)
+        now = datetime.now().replace(tzinfo=None)
+        try_until = now + timedelta(minutes=30)
+        slow_down_after = now + timedelta(minutes=2)
 
         while True:
             # old: was also logging {json.dumps(complete.to_json(), indent=4)}
             # alt: save it in ~/.semgrep/logs/complete.json?
             logger.debug(f"Sending /complete")
 
-            if datetime.utcnow() > try_until:
+            if datetime.now().replace(tzinfo=None) > try_until:
                 # let the backend know we won't be trying again
                 complete.final_attempt = True
 
@@ -522,4 +523,4 @@ class ScanHandler:
                 )
 
             progress_bar.advance(complete_task)
-            sleep(5 if datetime.utcnow() < slow_down_after else 30)
+            sleep(5 if datetime.now().replace(tzinfo=None) < slow_down_after else 30)


### PR DESCRIPTION
    OSS repo was last synced with Pro commit: 5134d9cc489dc167d2fd57fb57171bc6a57e7463
    Synchronizing OSS repo with Pro commit 647bf3656f8d4e79c37136d579c7234908ce8e88
    There are 3 commit(s) to sync.
    Syncing...
    * 6ec5e0f7832 chore: fix uses of deprecated function utcnow (#2339)
    * 7a7dba2f40a chore: log the trace id in debug mode (#2337)
    * Skipping (empty) 647bf3656f8 chore: dedup running extra builds when benchmarking and pushing release canidates (#2342)
    Success!